### PR TITLE
improve testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0"
+        "php": ">=7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,10 @@
         "psr-4": {
             "IvoPetkov\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "IvoPetkov\\": "tests/"
+        }   
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0"?>
 <phpunit bootstrap="tests/bootstrap.php"
-         colors="false"
+         colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          stopOnFailure="true">
     <testsuites>
-        <testsuite>
+        <testsuite name="DataObject testing">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
     <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+        <whitelist>
             <directory>./src/</directory>
         </whitelist>
     </filter>

--- a/tests/DataListTest.php
+++ b/tests/DataListTest.php
@@ -94,7 +94,7 @@ class DataListTest extends DataListTestCase
 
         $this->assertFalse(isset($list[6]));
 
-        $this->setExpectedException('\Exception');
+        $this->expectException('\Exception');
         $list[7] = new DataObject(['value' => 'gg']);
     }
 
@@ -125,6 +125,24 @@ class DataListTest extends DataListTestCase
         $this->assertTrue($list->get(1) === null);
         $this->assertTrue($list->getLast() === null);
         $this->assertTrue($list->getRandom() === null);
+    }
+
+    /**
+     * 
+     */
+    public function testOffsetGetShouldReturnNull()
+    {
+        $list = new DataList();
+        $this->assertNull($list->offsetGet(0));
+    }
+
+    /**
+     * 
+     */
+    public function testCurrentShouldReturnNull()
+    {
+        $list = new DataList();
+        $this->assertNull($list->current());
     }
 
     /**
@@ -599,6 +617,15 @@ class DataListTest extends DataListTestCase
     /**
      *
      */
+    public function testShiftShouldReturnNull()
+    {
+        $list = new DataList();
+        $this->assertNull($list->shift());
+    }
+
+    /**
+     *
+     */
     public function testPopAndPush()
     {
         $data = [
@@ -621,6 +648,15 @@ class DataListTest extends DataListTestCase
         });
         $this->assertTrue($list[3]->value === 'd');
         $this->assertTrue($list->length === 4);
+    }
+
+    /**
+     *
+     */
+    public function testPopShouldReturnNull()
+    {
+        $list = new DataList();
+        $this->assertNull($list->pop());
     }
 
     /**
@@ -755,7 +791,7 @@ class DataListTest extends DataListTestCase
     public function testExceptions2()
     {
         $dataList = new DataList();
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $dataList[false] = ['key' => 'value'];
     }
 
@@ -765,7 +801,7 @@ class DataListTest extends DataListTestCase
     public function testExceptions4()
     {
         $dataList = new DataList();
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $dataList->missing = 5;
     }
 
@@ -775,7 +811,7 @@ class DataListTest extends DataListTestCase
     public function testExceptions5()
     {
         $dataList = new DataList();
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         echo $dataList->missing;
     }
 
@@ -785,7 +821,7 @@ class DataListTest extends DataListTestCase
     public function testExceptions6()
     {
         $dataList = new DataList();
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $dataList->length = 5;
     }
 
@@ -795,7 +831,7 @@ class DataListTest extends DataListTestCase
     public function testExceptions7()
     {
         $dataList = new DataList();
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $dataList->sortBy('name', 1);
     }
 
@@ -805,8 +841,17 @@ class DataListTest extends DataListTestCase
     public function testExceptions10()
     {
         $dataList = new DataList();
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $dataList->filterBy('name', 'John', 'invalidOperator');
+    }
+
+    /**
+     *
+     */
+    public function testDataListInstanceWithInvalidConstructor()
+    {
+        $this->expectException('InvalidArgumentException');
+        $dataList = new DataList('invalid_data_source');
     }
 
     /**

--- a/tests/DataListTest.php
+++ b/tests/DataListTest.php
@@ -175,6 +175,46 @@ class DataListTest extends DataListTestCase
     /**
      *
      */
+    public function testUnsetWithInvalidProperty()
+    {
+        $this->expectException('Exception');
+        $data = [
+            ['value' => 'a'],
+            ['value' => 'b'],
+            function() {
+                return ['value' => 'c'];
+            },
+            function() {
+                return ['value' => 'd'];
+            }
+        ];
+        $list = new DataList($data);
+        unset($list->invalid_property);
+    }
+
+    /**
+     *
+     */
+    public function testUnsetWithReadonlyProperty()
+    {
+        $this->expectException('Exception');
+        $data = [
+            ['value' => 'a'],
+            ['value' => 'b'],
+            function() {
+                return ['value' => 'c'];
+            },
+            function() {
+                return ['value' => 'd'];
+            }
+        ];
+        $list = new DataList($data);
+        unset($list->length);
+    }
+
+    /**
+     *
+     */
     public function testConcat()
     {
         $list1 = new DataList([

--- a/tests/DataObjectTest.php
+++ b/tests/DataObjectTest.php
@@ -30,7 +30,7 @@ class DataObjectTest extends DataListTestCase
         $this->assertTrue($object->property1 === 'a');
         $this->assertTrue($object->property2 === 'b');
         $this->assertTrue($object->property3 === 'c');
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         echo $object->property4;
     }
 
@@ -145,7 +145,7 @@ class DataObjectTest extends DataListTestCase
         unset($object->property1);
         $this->assertFalse(isset($object->property1));
 
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         echo $object->property1;
     }
 
@@ -166,7 +166,7 @@ class DataObjectTest extends DataListTestCase
         unset($object['property1']);
         $this->assertFalse(isset($object['property1']));
 
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         echo $object['property1'];
     }
 
@@ -323,7 +323,7 @@ class DataObjectTest extends DataListTestCase
             }
         };
 
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
 
         $object->property1 = true;
     }
@@ -343,7 +343,7 @@ class DataObjectTest extends DataListTestCase
             }
         };
 
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
 
         unset($object->property1);
     }
@@ -364,7 +364,7 @@ class DataObjectTest extends DataListTestCase
     public function testEmptyObject2()
     {
         $object = new DataObject();
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         echo $object->property1;
     }
 
@@ -374,7 +374,7 @@ class DataObjectTest extends DataListTestCase
     public function testEmptyObject3()
     {
         $object = new DataObject();
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         echo $object['property1'];
     }
 
@@ -385,7 +385,7 @@ class DataObjectTest extends DataListTestCase
     {
         $object = new DataObject();
         unset($object->property1);
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         echo $object->property1;
     }
 
@@ -521,7 +521,7 @@ class DataObjectTest extends DataListTestCase
      */
     public function testExceptions1()
     {
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object = new class extends DataObject {
 
             protected function initialize()
@@ -538,7 +538,7 @@ class DataObjectTest extends DataListTestCase
      */
     public function testExceptions2()
     {
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object = new class extends DataObject {
 
             protected function initialize()
@@ -555,7 +555,7 @@ class DataObjectTest extends DataListTestCase
      */
     public function testExceptions3()
     {
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object = new class extends DataObject {
 
             protected function initialize()
@@ -572,7 +572,7 @@ class DataObjectTest extends DataListTestCase
      */
     public function testExceptions4()
     {
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object = new class extends DataObject {
 
             protected function initialize()
@@ -589,7 +589,7 @@ class DataObjectTest extends DataListTestCase
      */
     public function testExceptions5()
     {
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object = new class extends DataObject {
 
             protected function initialize()
@@ -645,7 +645,7 @@ class DataObjectTest extends DataListTestCase
     public function testPropertyTypes1b()
     {
         $object = $this->getDataObjectWithPropertyType('string');
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object->property1 = null;
     }
 
@@ -655,7 +655,7 @@ class DataObjectTest extends DataListTestCase
     public function testPropertyTypes1c()
     {
         $object = $this->getDataObjectWithPropertyType('?string');
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object->property1 = 1;
     }
 
@@ -679,7 +679,7 @@ class DataObjectTest extends DataListTestCase
     public function testPropertyTypes2b()
     {
         $object = $this->getDataObjectWithPropertyType('int');
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object->property1 = null;
     }
 
@@ -689,7 +689,7 @@ class DataObjectTest extends DataListTestCase
     public function testPropertyTypes2c()
     {
         $object = $this->getDataObjectWithPropertyType('?int');
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object->property1 = 'value';
     }
 
@@ -713,7 +713,7 @@ class DataObjectTest extends DataListTestCase
     public function testPropertyTypes3b()
     {
         $object = $this->getDataObjectWithPropertyType('array');
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object->property1 = null;
     }
 
@@ -723,7 +723,7 @@ class DataObjectTest extends DataListTestCase
     public function testPropertyTypes3c()
     {
         $object = $this->getDataObjectWithPropertyType('?array');
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object->property1 = 'value';
     }
 
@@ -762,7 +762,7 @@ class DataObjectTest extends DataListTestCase
                         };
             }
         ]);
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object->property1 = null;
     }
 
@@ -772,7 +772,7 @@ class DataObjectTest extends DataListTestCase
     public function testPropertyTypes4c()
     {
         $object = $this->getDataObjectWithPropertyType('?callable');
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object->property1 = 'value';
     }
 
@@ -796,7 +796,7 @@ class DataObjectTest extends DataListTestCase
     public function testPropertyTypes5b()
     {
         $object = $this->getDataObjectWithPropertyType('float');
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object->property1 = null;
     }
 
@@ -806,7 +806,7 @@ class DataObjectTest extends DataListTestCase
     public function testPropertyTypes5c()
     {
         $object = $this->getDataObjectWithPropertyType('?float');
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object->property1 = 'value';
     }
 
@@ -838,7 +838,7 @@ class DataObjectTest extends DataListTestCase
                 return true;
             }
         ]);
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object->property1 = null;
     }
 
@@ -848,7 +848,7 @@ class DataObjectTest extends DataListTestCase
     public function testPropertyTypes6c()
     {
         $object = $this->getDataObjectWithPropertyType('?bool');
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object->property1 = 'value';
     }
 
@@ -881,7 +881,7 @@ class DataObjectTest extends DataListTestCase
                 return new DateTime();
             }
         ]);
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object->property1 = null;
     }
 
@@ -891,7 +891,7 @@ class DataObjectTest extends DataListTestCase
     public function testPropertyTypes7c()
     {
         $object = $this->getDataObjectWithPropertyType('?DateTime');
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object->property1 = 'value';
     }
 
@@ -905,7 +905,7 @@ class DataObjectTest extends DataListTestCase
                 return new DateTime();
             }
         ]);
-        $this->setExpectedException('Exception');
+        $this->expectException('Exception');
         $object->property1 = new stdClass();
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,7 +7,7 @@
  * Free to use under the MIT license.
  */
 
-class DataListTestCase extends PHPUnit_Framework_TestCase
+class DataListTestCase extends PHPUnit\Framework\TestCase
 {
 
     function setUp()
@@ -17,7 +17,7 @@ class DataListTestCase extends PHPUnit_Framework_TestCase
 
 }
 
-class DataListAutoloaderTestCase extends PHPUnit_Framework_TestCase
+class DataListAutoloaderTestCase extends PHPUnit\Framework\TestCase
 {
 
     function setUp()


### PR DESCRIPTION
# changed log

- using the stable PHPUnit version 6.
- replace the ```PHPUnit_Framework_TestCase``` with ```PHPUnit\Framework\TestCase``` name space.
- According to this [issue](https://github.com/sebastianbergmann/phpunit/issues/2074), replace setExpectedException() with expectException().
- add the autoload-dev in ```composer.json```.
- improve code coverage.
- change the required minimum PHP version in ```composer.json``` because of the source code syntax.